### PR TITLE
pyhon > 3.6 compatibility fix

### DIFF
--- a/src/python_interface/bandupy/files.py
+++ b/src/python_interface/bandupy/files.py
@@ -244,7 +244,7 @@ def create_bandup_input(args):
                                                  ("dE",args.dE)])
         with open(energy_info_file, 'w') as f:
             f.write(file_header())
-            for k,v in energy_info_file_contents.iteritems():
+            for k,v in energy_info_file_contents.items():
                 f.write("%.5f  # %s \n"%(v,k))
 
     # PC, SC and PC-KPT files
@@ -287,7 +287,7 @@ def create_bandup_input(args):
 
     # Creating/verifying files
     # Wavefunction files will not be copied. Symlinks will be made in this case
-    for source, dest_properties in origin2dest.iteritems():
+    for source, dest_properties in origin2dest.items():
         assert_valid_path(source)
         dest = dest_properties['dest']
         to_be_copied = dest_properties['copy']
@@ -349,7 +349,7 @@ def create_bandup_plot_input(args):
                                                      ("emax",args.emax),
                                                      ("dE",args.dE)])
             with open(energy_info_file, 'w') as f:
-                for k,v in energy_info_file_contents.iteritems():
+                for k,v in energy_info_file_contents.items():
                     f.write("%.5f  ! %s \n"%(v,k))
 
     # PC, SC, PC-KPT, and main input files
@@ -375,7 +375,7 @@ def create_bandup_plot_input(args):
 
     # Creating/verifying files
     # Wavefunction files will not be copied. Symlinks will be made in this case
-    for source, dest_properties in origin2dest.iteritems():
+    for source, dest_properties in origin2dest.items():
         assert_valid_path(source)
         dest = dest_properties['dest']
         to_be_copied = dest_properties['copy']

--- a/src/python_interface/bandupy/runners.py
+++ b/src/python_interface/bandupy/runners.py
@@ -13,7 +13,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with BandUP.  If not, see <http://www.gnu.org/licenses/>.
-from subprocess import Popen, PIPE, STDOUT
+from subprocess import run, STDOUT
 import os
 import sys
 # Imports from within the package
@@ -33,11 +33,11 @@ def run_bandup(args):
     # Running BandUP
     os.chdir(args.results_dir)
     bandup_run_options = [BANDUP_BIN] + args.argv
+    bandup_run = run(bandup_run_options, capture_output=True,
+                     text=True)
+    sys.stdout.write(bandup_run.stdout)
     with open("out_BandUP.dat", 'w') as f:
-        bandup_run = Popen(bandup_run_options, stdout=PIPE, stderr=STDOUT)
-        for line in iter(bandup_run.stdout.readline, ''):
-            sys.stdout.write(line)
-            f.write(line)
+            f.write(bandup_run.stdout)
     if(args.orbitals):
         get_orbital_projections_and_duals(args)
     os.chdir(start_dir)
@@ -47,12 +47,11 @@ def run_pre_bandup_tool(args):
     # Running BandUP pre-unfolding tool
     os.chdir(args.inputs_dir)
     bandup_pre_unf_run_options = [BANDUP_PRE_UNFOLDING_BIN] + args.argv
+    bandup_pre_unf_run = run(bandup_pre_unf_run_options, capture_output=True,
+                             text=True)
+    sys.stdout.write(bandup_pre_unf_run.stdout)
     with open("out_BandUP_get_SCKPTS_pre_unfolding.dat", 'w') as f:
-        bandup_pre_unf_run = Popen(bandup_pre_unf_run_options, 
-                                   stdout=PIPE, stderr=STDOUT)
-        for line in iter(bandup_pre_unf_run.stdout.readline, ''):
-            sys.stdout.write(line)
-            f.write(line)
+        f.write(bandup_pre_unf_run.stdout)
     os.chdir(start_dir)
 
 

--- a/src/python_interface/bandupy/runners.py
+++ b/src/python_interface/bandupy/runners.py
@@ -13,7 +13,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with BandUP.  If not, see <http://www.gnu.org/licenses/>.
-from subprocess import run, STDOUT
+from subprocess import Popen, PIPE, STDOUT
 import os
 import sys
 # Imports from within the package
@@ -33,11 +33,11 @@ def run_bandup(args):
     # Running BandUP
     os.chdir(args.results_dir)
     bandup_run_options = [BANDUP_BIN] + args.argv
-    bandup_run = run(bandup_run_options, capture_output=True,
-                     text=True)
-    sys.stdout.write(bandup_run.stdout)
     with open("out_BandUP.dat", 'w') as f:
-            f.write(bandup_run.stdout)
+        bandup_run = Popen(bandup_run_options, stdout=PIPE, stderr=STDOUT,encoding='UTF-8')
+        for line in iter(bandup_run.stdout.readline, ''):
+            sys.stdout.write(line)
+            f.write(line)
     if(args.orbitals):
         get_orbital_projections_and_duals(args)
     os.chdir(start_dir)
@@ -47,11 +47,12 @@ def run_pre_bandup_tool(args):
     # Running BandUP pre-unfolding tool
     os.chdir(args.inputs_dir)
     bandup_pre_unf_run_options = [BANDUP_PRE_UNFOLDING_BIN] + args.argv
-    bandup_pre_unf_run = run(bandup_pre_unf_run_options, capture_output=True,
-                             text=True)
-    sys.stdout.write(bandup_pre_unf_run.stdout)
     with open("out_BandUP_get_SCKPTS_pre_unfolding.dat", 'w') as f:
-        f.write(bandup_pre_unf_run.stdout)
+        bandup_pre_unf_run = Popen(bandup_pre_unf_run_options, 
+                                   stdout=PIPE, stderr=STDOUT)
+        for line in iter(bandup_pre_unf_run.stdout.readline, ''):
+            sys.stdout.write(line)
+            f.write(line)
     os.chdir(start_dir)
 
 

--- a/src/python_interface/bandupy/warnings_wrapper.py
+++ b/src/python_interface/bandupy/warnings_wrapper.py
@@ -21,7 +21,8 @@ import sys
 class WarningError(UserWarning):
     pass
 
-def _new_showwarning(message, category = UserWarning, filename = '', lineno = -1):
+def _new_showwarning(message, category = UserWarning, filename = '',
+                     lineno = -1, msg_file=None, line=None):
     if(category==WarningError):
         warn_msg = 'ERROR '
     else:


### PR DESCRIPTION
- run function replace popen
- the logic to write the STDOUT to file hs been changed accordingly
- iteritems() replaced with items()

I tested the three mode kpts, unfold and plot and they seems working fine with python > 3.6.

An error is raised if py 3.5 is used, though

hope this is helpful 