### PR TITLE
removed the quotes in grep for VASP examples

### DIFF
--- a/tutorial/VASP/example_1_graphene_rectangular_SC/step_3_get_SC_wavefunctions_to_be_used_for_unfolding/job_for_band_unfolding.sh
+++ b/tutorial/VASP/example_1_graphene_rectangular_SC/step_3_get_SC_wavefunctions_to_be_used_for_unfolding/job_for_band_unfolding.sh
@@ -8,12 +8,12 @@ sc_calc_folder='../step_1_*/'
 CHGCAR=${sc_calc_folder}'/CHGCAR'
 POSCAR=${sc_calc_folder}'/POSCAR'
 # Grid stuff
-NGX=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[5]}'`
-NGY=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
-NGZ=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[11]}'`
-NGXF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[4]}'`
-NGYF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[6]}'`
-NGZF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
+NGX=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[5]}'`
+NGY=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
+NGZ=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[11]}'`
+NGXF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[4]}'`
+NGYF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[6]}'`
+NGZF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
 
 # Preparing inputs
 cp $POSCAR POSCAR

--- a/tutorial/VASP/example_2_bulk_Si/step_3_get_SC_wavefunctions_to_be_used_for_unfolding/job_for_band_unfolding.sh
+++ b/tutorial/VASP/example_2_bulk_Si/step_3_get_SC_wavefunctions_to_be_used_for_unfolding/job_for_band_unfolding.sh
@@ -8,12 +8,12 @@ sc_calc_folder='../step_1_*/'
 CHGCAR=${sc_calc_folder}'/CHGCAR'
 POSCAR=${sc_calc_folder}'/POSCAR'
 # Grid stuff
-NGX=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[5]}'`
-NGY=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
-NGZ=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[11]}'`
-NGXF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[4]}'`
-NGYF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[6]}'`
-NGZF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
+NGX=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[5]}'`
+NGY=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
+NGZ=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[11]}'`
+NGXF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[4]}'`
+NGYF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[6]}'`
+NGZF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
 
 # Preparing inputs
 cp $POSCAR POSCAR

--- a/tutorial/VASP/example_3_bulk_Si_other_set_of_pcbz_directions/step_3_get_SC_wavefunctions_to_be_used_for_unfolding/job_for_band_unfolding.sh
+++ b/tutorial/VASP/example_3_bulk_Si_other_set_of_pcbz_directions/step_3_get_SC_wavefunctions_to_be_used_for_unfolding/job_for_band_unfolding.sh
@@ -8,12 +8,12 @@ sc_calc_folder='../step_1_*/'
 CHGCAR=${sc_calc_folder}'/CHGCAR'
 POSCAR=${sc_calc_folder}'/POSCAR'
 # Grid stuff
-NGX=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[5]}'`
-NGY=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
-NGZ=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[11]}'`
-NGXF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[4]}'`
-NGYF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[6]}'`
-NGZF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
+NGX=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[5]}'`
+NGY=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
+NGZ=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[11]}'`
+NGXF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[4]}'`
+NGYF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[6]}'`
+NGZF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
 
 # Preparing inputs
 cp $POSCAR POSCAR

--- a/tutorial/VASP/example_4_graphene_on_copper/step_3_get_SC_wavefunctions_to_be_used_for_unfolding/job_for_band_unfolding.sh
+++ b/tutorial/VASP/example_4_graphene_on_copper/step_3_get_SC_wavefunctions_to_be_used_for_unfolding/job_for_band_unfolding.sh
@@ -8,12 +8,12 @@ sc_calc_folder='../step_1_*/'
 CHGCAR=${sc_calc_folder}'/CHGCAR'
 POSCAR=${sc_calc_folder}'/POSCAR'
 # Grid stuff
-NGX=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[5]}'`
-NGY=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
-NGZ=`grep 'dimension x,y,z NGX =' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[11]}'`
-NGXF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[4]}'`
-NGYF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[6]}'`
-NGZF=`grep 'dimension x,y,z NGXF=' "${sc_calc_folder}/OUTCAR" | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
+NGX=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[5]}'`
+NGY=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
+NGZ=` grep 'dimension x,y,z NGX =' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[11]}'`
+NGXF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[4]}'`
+NGYF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[6]}'`
+NGZF=`grep 'dimension x,y,z NGXF=' ${sc_calc_folder}/OUTCAR | head -1 | awk '{split($0,array," ")} END{print array[8]}'`
 
 # Preparing inputs
 cp $POSCAR POSCAR


### PR DESCRIPTION
changed the scripts in VASP tutorials on step 3 to do the `grep` command. 

Did it ever work, actually?
